### PR TITLE
Use the statically statically updated version of AnyBossNPCS

### DIFF
--- a/Content/Backgrounds/ProfanedGardenLavaBackground.cs
+++ b/Content/Backgrounds/ProfanedGardenLavaBackground.cs
@@ -1,4 +1,5 @@
 ﻿using CalamityMod;
+using CalamityMod.CalPlayer;
 using Microsoft.Xna.Framework;
 using Terraria;
 
@@ -12,8 +13,8 @@ namespace InfernumMode.Content.Backgrounds
         {
             get
             {
-                Color dayColor = Color.Lerp(Color.Orange, Color.Wheat, 0.67f) with { A = 0 } * (CalamityUtils.AnyBossNPCS() ? 0.45f : 1f);
-                Color nightColor = Color.Lerp(Color.MediumBlue, Color.Yellow, 0.3f) with { A = 0 } * (CalamityUtils.AnyBossNPCS() ? 0.35f : 1f);
+                Color dayColor = Color.Lerp(Color.Orange, Color.Wheat, 0.67f) with { A = 0 } * (CalamityPlayer.areThereAnyDamnBosses ? 0.45f : 1f);
+                Color nightColor = Color.Lerp(Color.MediumBlue, Color.Yellow, 0.3f) with { A = 0 } * (CalamityPlayer.areThereAnyDamnBosses ? 0.35f : 1f);
                 float nightInterpolant = 1f;
                 if (Main.dayTime)
                     nightInterpolant = 1f - Utils.GetLerpValue(0f, 1500f, (float)Main.time, true) * Utils.GetLerpValue((float)Main.dayLength, (float)Main.dayLength - 1500f, (float)Main.time, true);

--- a/Core/GlobalInstances/Systems/CalamitasCragsSpawnSystem.cs
+++ b/Core/GlobalInstances/Systems/CalamitasCragsSpawnSystem.cs
@@ -1,4 +1,5 @@
 using CalamityMod;
+using CalamityMod.CalPlayer;
 using InfernumMode.Content.BehaviorOverrides.BossAIs.SupremeCalamitas.CragsCutscene;
 using Microsoft.Xna.Framework;
 using Terraria;
@@ -32,7 +33,7 @@ namespace InfernumMode.Core.GlobalInstances.Systems
             for (int i = 0; i < Main.maxPlayers; i++)
             {
                 Player p = Main.player[i];
-                if (!p.dead && p.active && !CalamityUtils.AnyBossNPCS() && p.Calamity().ZoneCalamity && p.WithinRange(calSpawnPosition, 1800f) && !p.WithinRange(calSpawnPosition, 1000f))
+                if (!p.dead && p.active && !CalamityPlayer.areThereAnyDamnBosses && p.Calamity().ZoneCalamity && p.WithinRange(calSpawnPosition, 1800f) && !p.WithinRange(calSpawnPosition, 1000f))
                 {
                     Utilities.NewProjectileBetter(calSpawnPosition, Vector2.Zero, ModContent.ProjectileType<CalamitasCutsceneProj>(), 0, 0f);
                     WorldSaveSystem.MetCalamitasAtCrags = true;

--- a/Core/GlobalInstances/Systems/CeaselessVoidArchivesSpawnSystem.cs
+++ b/Core/GlobalInstances/Systems/CeaselessVoidArchivesSpawnSystem.cs
@@ -1,4 +1,5 @@
 using CalamityMod;
+using CalamityMod.CalPlayer;
 using CalamityMod.Events;
 using CalamityMod.NPCs;
 using CalamityMod.NPCs.CeaselessVoid;
@@ -30,7 +31,7 @@ namespace InfernumMode.Core.GlobalInstances.Systems
             for (int i = 0; i < Main.maxPlayers; i++)
             {
                 Player p = Main.player[i];
-                if (!p.dead && p.active && !CalamityUtils.AnyBossNPCS() && p.ZoneDungeon && p.WithinRange(voidSpawnPosition, 2000f) && CalamityGlobalNPC.voidBoss == -1)
+                if (!p.dead && p.active && !CalamityPlayer.areThereAnyDamnBosses && p.ZoneDungeon && p.WithinRange(voidSpawnPosition, 2000f) && CalamityGlobalNPC.voidBoss == -1)
                 {
                     int ceaselessVoid = NPC.NewNPC(new EntitySource_WorldEvent(), (int)voidSpawnPosition.X, (int)voidSpawnPosition.Y, ModContent.NPCType<CeaselessVoid>(), 0, 0f, 0f, 0f, 1f);
                     NetMessage.SendData(MessageID.SyncNPC, -1, -1, null, ceaselessVoid);

--- a/Core/GlobalInstances/Systems/SignusGardenSpawnSystem.cs
+++ b/Core/GlobalInstances/Systems/SignusGardenSpawnSystem.cs
@@ -1,4 +1,5 @@
 using CalamityMod;
+using CalamityMod.CalPlayer;
 using CalamityMod.NPCs.Signus;
 using Microsoft.Xna.Framework;
 using Terraria;
@@ -19,7 +20,7 @@ namespace InfernumMode.Core.GlobalInstances.Systems
             for (int i = 0; i < Main.maxPlayers; i++)
             {
                 Player p = Main.player[i];
-                if (!p.dead && p.active && !CalamityUtils.AnyBossNPCS() && p.Infernum_Biome().ZoneProfaned && p.WithinRange(signusSpawnPosition, 2000f))
+                if (!p.dead && p.active && CalamityPlayer.areThereAnyDamnBosses && p.Infernum_Biome().ZoneProfaned && p.WithinRange(signusSpawnPosition, 2000f))
                 {
                     int signus = NPC.NewNPC(new EntitySource_WorldEvent(), (int)signusSpawnPosition.X, (int)signusSpawnPosition.Y, ModContent.NPCType<Signus>(), 0, 0f, 0f, 0f, 1f);
                     NetMessage.SendData(MessageID.SyncNPC, -1, -1, null, signus);


### PR DESCRIPTION
This converts most usages of `AnyBossNPCS` to use the `areThereAnyDamnBosses` field on the `CalamityPlayer` class. Using this field over calling the method can save a lot of CPU time every frame. (From my experimentation 10~% of the tick could be saved by doing this).